### PR TITLE
protocol changes to support latest pm4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,9 @@
 {
 	"name": "colinhdev/actualantixray",
 	"require": {
-		"pocketmine/pocketmine-mp": "dev-stable"
-	},
+		"pocketmine/pocketmine-mp": "dev-stable",
+      	"ext-igbinary": "*"
+    },
 	"require-dev": {
 		"phpstan/phpstan": "^1.8.1",
 		"phpstan/phpstan-strict-rules": "^1.3.0",

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: ActualAntiXRay
 main: ColinHDev\ActualAntiXRay\ActualAntiXRay
 version: "1.0.1"
 
-api: 4.2.0
+api: 4.7.0
 
 author: ColinHDev
 website: https://github.com/ColinHDev

--- a/src/ColinHDev/ActualAntiXRay/player/Player.php
+++ b/src/ColinHDev/ActualAntiXRay/player/Player.php
@@ -215,7 +215,7 @@ class Player extends PMMP_PLAYER {
                     $chunk,
                     $caches[$chunkHash],
                     $compressor,
-                    function() use ($world, $chunkCache, $chunkHash, $chunkX, $chunkZ) : void {
+                    function() use ($world, $chunkCache, $chunkHash, $chunkX, $chunkZ) : void{
                         $world->getLogger()->error("Failed preparing chunk $chunkX $chunkZ, retrying");
 
                         $property = new ReflectionProperty(ChunkCache::class, "caches");

--- a/src/ColinHDev/ActualAntiXRay/player/Player.php
+++ b/src/ColinHDev/ActualAntiXRay/player/Player.php
@@ -222,7 +222,7 @@ class Player extends PMMP_PLAYER {
                         $property->setAccessible(true);
                         /** @var CompressBatchPromise[] $caches */
                         $caches = $property->getValue($chunkCache);
-                        if (isset($caches[$chunkHash])){
+                        if(isset($caches[$chunkHash])){
                             $this->restartPendingRequest($chunkCache, $chunkX, $chunkZ);
                         }
                     }

--- a/src/ColinHDev/ActualAntiXRay/player/Player.php
+++ b/src/ColinHDev/ActualAntiXRay/player/Player.php
@@ -215,14 +215,14 @@ class Player extends PMMP_PLAYER {
                     $chunk,
                     $caches[$chunkHash],
                     $compressor,
-                    function() use ($world, $chunkCache, $chunkHash, $chunkX, $chunkZ) : void{
+                    function() use ($world, $chunkCache, $chunkHash, $chunkX, $chunkZ) : void {
                         $world->getLogger()->error("Failed preparing chunk $chunkX $chunkZ, retrying");
 
                         $property = new ReflectionProperty(ChunkCache::class, "caches");
                         $property->setAccessible(true);
                         /** @var CompressBatchPromise[] $caches */
                         $caches = $property->getValue($chunkCache);
-                        if(isset($caches[$chunkHash])){
+                        if (isset($caches[$chunkHash])){
                             $this->restartPendingRequest($chunkCache, $chunkX, $chunkZ);
                         }
                     }

--- a/src/ColinHDev/ActualAntiXRay/tasks/ChunkRequestTask.php
+++ b/src/ColinHDev/ActualAntiXRay/tasks/ChunkRequestTask.php
@@ -14,6 +14,7 @@ use pocketmine\network\mcpe\convert\RuntimeBlockMapping;
 use pocketmine\network\mcpe\protocol\LevelChunkPacket;
 use pocketmine\network\mcpe\protocol\serializer\PacketBatch;
 use pocketmine\network\mcpe\protocol\serializer\PacketSerializerContext;
+use pocketmine\network\mcpe\protocol\types\ChunkPosition;
 use pocketmine\network\mcpe\serializer\ChunkSerializer;
 use pocketmine\utils\AssumptionFailedError;
 use pocketmine\world\ChunkLoader;
@@ -169,7 +170,7 @@ class ChunkRequestTask extends PMMPChunkRequestTask {
         $subCount = ChunkSerializer::getSubChunkCount($chunk) + ChunkSerializer::LOWER_PADDING_SIZE;
         $encoderContext = new PacketSerializerContext(GlobalItemTypeDictionary::getInstance()->getDictionary());
         $payload = ChunkSerializer::serializeFullChunk($chunk, RuntimeBlockMapping::getInstance(), $encoderContext, $this->tiles);
-        $this->setResult($this->compressor->compress(PacketBatch::fromPackets($encoderContext, LevelChunkPacket::create($this->chunkX, $this->chunkZ, $subCount, false, null, $payload))->getBuffer()));
+        $this->setResult($this->compressor->compress(PacketBatch::fromPackets($encoderContext, LevelChunkPacket::create(new ChunkPosition($this->chunkX, $this->chunkZ), $subCount, false, null, $payload))->getBuffer()));
     }
 
     private function isBlockReplaceable(SubChunkExplorer $explorer, Vector3 $vector, int $subChunkY) : bool {


### PR DESCRIPTION
This will fix

`[14:25:46.497] [AsyncWorker#11 thread/CRITICAL]: TypeError: "pocketmine\network\mcpe\protocol\LevelChunkPacket::create(): Argument #1 ($chunkPosition) must be of type pocketmine\network\mcpe\protocol\types\ChunkPosition, int given, called in /home/debian/mcpe/BACKUP_NW/PM4-Test_Server/plugins/ActualAntiXRay-main/src/ColinHDev/ActualAntiXRay/tasks/ChunkRequestTask.php on line 172" (EXCEPTION) in "pmsrc/vendor/pocketmine/bedrock-protocol/src/LevelChunkPacket" at line 47
--- Stack trace ---
  #0 /home/debian/mcpe/BACKUP_NW/PM4-Test_Server/plugins/ActualAntiXRay-main/src/ColinHDev/ActualAntiXRay/tasks/ChunkRequestTask(172): pocketmine\network\mcpe\protocol\LevelChunkPacket::create(int -2, int -1, int 9, false, null, string[7627] ................................................................................)
  #1 pmsrc/src/scheduler/AsyncTask(90): ColinHDev\ActualAntiXRay\tasks\ChunkRequestTask->onRun()
  #2 (): pocketmine\scheduler\AsyncTask->run()
--- End of exception information ---
`